### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -2,7 +2,6 @@
 title = "Study mdBook"
 authors = ["kkAyataka"]
 language = "ja"
-multilingual = false
 src = "docs"
 
 [preprocessor.mermaid]


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10